### PR TITLE
Scalable room-scoped LiveKit key rotation

### DIFF
--- a/src/app/api/livekit-token/route.ts
+++ b/src/app/api/livekit-token/route.ts
@@ -37,19 +37,28 @@ function getKeySets(): LiveKitKeySet[] {
   return sets;
 }
 
-// Track which key set is currently active (round-robin on quota errors)
-let activeKeyIndex = 0;
 // Track exhausted keys with cooldown (avoid hammering a key that just hit quota)
 const exhaustedUntil = new Map<number, number>();
 const COOLDOWN_MS = 5 * 60 * 1000; // 5 min cooldown after quota hit
 
-function getActiveKeySet(keySets: LiveKitKeySet[]): { keySet: LiveKitKeySet; index: number } | null {
+// Hash room code to a key index - ensures all users in the same room
+// get the same LiveKit project (rooms are project-scoped)
+function roomKeyIndex(room: string, total: number): number {
+  let hash = 0;
+  for (let i = 0; i < room.length; i++) {
+    hash = ((hash << 5) - hash + room.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash) % total;
+}
+
+function getKeySetForRoom(room: string, keySets: LiveKitKeySet[], offset = 0): { keySet: LiveKitKeySet; index: number } | null {
   const now = Date.now();
   const total = keySets.length;
+  const baseIdx = roomKeyIndex(room, total);
 
-  // Try each key starting from activeKeyIndex
+  // Try keys starting from the room's hashed index + offset
   for (let attempt = 0; attempt < total; attempt++) {
-    const idx = (activeKeyIndex + attempt) % total;
+    const idx = (baseIdx + offset + attempt) % total;
     const cooldownEnd = exhaustedUntil.get(idx);
 
     if (!cooldownEnd || now > cooldownEnd) {
@@ -57,7 +66,7 @@ function getActiveKeySet(keySets: LiveKitKeySet[]): { keySet: LiveKitKeySet; ind
     }
   }
 
-  // All keys exhausted — use the one with the shortest remaining cooldown
+  // All keys exhausted - use the one with the shortest remaining cooldown
   let bestIdx = 0;
   let bestTime = Infinity;
   for (const [idx, until] of exhaustedUntil) {
@@ -71,12 +80,7 @@ function getActiveKeySet(keySets: LiveKitKeySet[]): { keySet: LiveKitKeySet; ind
 
 function markExhausted(index: number) {
   exhaustedUntil.set(index, Date.now() + COOLDOWN_MS);
-  console.log(`[LiveKit] Key set #${index + 1} hit quota — cooldown for ${COOLDOWN_MS / 1000}s`);
-}
-
-function rotateToNext(keySets: LiveKitKeySet[], currentIndex: number) {
-  activeKeyIndex = (currentIndex + 1) % keySets.length;
-  console.log(`[LiveKit] Rotated to key set #${activeKeyIndex + 1}`);
+  console.log(`[LiveKit] Key set #${index + 1} hit quota - cooldown for ${COOLDOWN_MS / 1000}s`);
 }
 
 export async function GET(req: NextRequest) {
@@ -100,16 +104,13 @@ export async function GET(req: NextRequest) {
       );
     }
 
-    // If client reported a connect failure, rotate to next key
-    if (keyHint === "next" && keySets.length > 1) {
-      markExhausted(activeKeyIndex);
-      rotateToNext(keySets, activeKeyIndex);
-    }
+    // If client reported a connect failure, try the next key for this room
+    const offset = keyHint === "next" ? 1 : 0;
 
-    // Try key sets with failover
+    // Try key sets with failover (starting from the room's hashed key)
     let lastError: unknown = null;
     for (let attempt = 0; attempt < keySets.length; attempt++) {
-      const active = getActiveKeySet(keySets);
+      const active = getKeySetForRoom(room, keySets, offset + attempt);
       if (!active) break;
 
       try {
@@ -156,8 +157,7 @@ export async function GET(req: NextRequest) {
 
         if (isQuotaError) {
           markExhausted(active.index);
-          rotateToNext(keySets, active.index);
-          continue; // try next key
+          continue; // try next key for this room
         }
 
         // Non-quota error — don't rotate, just fail


### PR DESCRIPTION
## Summary
- Auto-discovers LIVEKIT_API_KEY_N env vars (up to _20) - no hardcoded key sets
- Room-scoped key assignment via hash - all users in the same room always get the same LiveKit project
- Failover with 5-min cooldown per exhausted key

## Why room-scoped?
LiveKit rooms are project-scoped. If user A connects on project 1 and user B on project 2, they can't hear each other even in the "same" room. The hash ensures consistent assignment.

## How it works
- Room code is hashed to pick a base key index
- If that key is exhausted, falls through to next available
- Client sends `?keyHint=next` on connect failure to try a different key
- Distribution is even across keys by room name, not sequential

## Adding keys
Just add env vars - no code changes:
```
LIVEKIT_API_KEY_4=...
LIVEKIT_API_SECRET_4=...
LIVEKIT_URL_4=wss://...  (optional, falls back to primary)
```

## Test plan
- [ ] Single key: works as before (no behavioral change)
- [ ] Two keys: different room codes hash to different keys
- [ ] Same room code always gets the same key (verified by checking token URL)
- [ ] Exhausted key: client retries with keyHint=next, gets a different key