### PR TITLE
Fix 6 cleanup/lifecycle issues from stateless audit

### DIFF
--- a/party/index.ts
+++ b/party/index.ts
@@ -70,12 +70,13 @@ export default class KaraokeRoom implements Party.Server {
     this.singerTimer = null;
     if (this.currentSingerId) {
       this.singerTimer = setTimeout(() => {
-        if (this.currentSingerId && !this.participants.has(this.currentSingerId)) {
-          console.log(`[KaraokeRoom] Singer ${this.currentSingerId} timed out — advancing queue`);
-          this.currentSingerId = null;
-          this.promoteNextSinger();
-          this.broadcastState();
-        }
+        if (!this.currentSingerId) return;
+        // Fire for both disconnected AND idle connected singers
+        console.log(`[KaraokeRoom] Singer ${this.currentSingerId} timed out - advancing queue`);
+        this.currentSingerId = null;
+        this.mutedBySinger = null;
+        this.promoteNextSinger();
+        this.broadcastState();
       }, SINGER_TIMEOUT_MS);
     }
   }
@@ -84,6 +85,15 @@ export default class KaraokeRoom implements Party.Server {
     this.lastPong.set(conn.id, Date.now());
     this.startHeartbeat();
     this.send(conn, { type: "you-joined", peerId: conn.id });
+
+    // Evict connections that don't send "join" within 10s
+    setTimeout(() => {
+      if (!this.participants.has(conn.id)) {
+        console.log(`[KaraokeRoom] Connection ${conn.id} never joined - disconnecting`);
+        this.lastPong.delete(conn.id);
+        try { conn.close(); } catch { /* already closed */ }
+      }
+    }, 10_000);
   }
 
   onMessage(message: string | ArrayBuffer | ArrayBufferView, sender: Party.Connection) {
@@ -148,11 +158,18 @@ export default class KaraokeRoom implements Party.Server {
   }
 
   onClose(conn: Party.Connection) {
+    // Clean up lastPong for pre-join connections that never called handleJoin
+    if (!this.participants.has(conn.id)) {
+      this.lastPong.delete(conn.id);
+    }
     this.removeParticipant(conn.id);
   }
 
   onError(conn: Party.Connection, _error: Error) {
     console.error(`[KaraokeRoom] Connection error for ${conn.id}`);
+    if (!this.participants.has(conn.id)) {
+      this.lastPong.delete(conn.id);
+    }
     this.removeParticipant(conn.id);
   }
 
@@ -173,11 +190,12 @@ export default class KaraokeRoom implements Party.Server {
       this.promoteNextSinger();
     }
 
-    // If room is now empty, reset all state so the DO can be GC'd cleanly
+    // If room is now empty, reset ALL state so the DO can be GC'd cleanly
     if (this.participants.size === 0) {
-      console.log(`[KaraokeRoom] Room ${this.room.id} is empty — resetting state`);
+      console.log(`[KaraokeRoom] Room ${this.room.id} is empty - resetting state`);
       this.queue = [];
       this.currentSingerId = null;
+      this.mutedBySinger = null;
       this.chatMessages = [];
       this.participantStatus.clear();
       this.lastPong.clear();
@@ -343,6 +361,17 @@ export default class KaraokeRoom implements Party.Server {
       status.browser = status.browser.slice(0, MAX_BROWSER_LENGTH);
     }
     this.participantStatus.set(sender.id, status);
+
+    // Singer timer: cancel while sharing, restart when idle
+    if (sender.id === this.currentSingerId) {
+      if (status.isSharingAudio) {
+        // Actively sharing - cancel idle timer (unlimited singing time)
+        if (this.singerTimer) { clearTimeout(this.singerTimer); this.singerTimer = null; }
+      } else {
+        // Not sharing - restart idle timer (60s to start/resume or get auto-advanced)
+        this.resetSingerTimer();
+      }
+    }
     // Send lightweight status update instead of full room state
     this.broadcast({
       type: "participant-status",

--- a/src/app/api/livekit-token/route.ts
+++ b/src/app/api/livekit-token/route.ts
@@ -130,6 +130,7 @@ export async function GET(req: NextRequest) {
         const at = new AccessToken(keySet.apiKey, keySet.apiSecret, {
           identity: uniqueId,
           name: name,
+          ttl: 3600, // 1 hour (default is 6h)
         });
 
         at.addGrant({

--- a/src/hooks/useLiveKit.ts
+++ b/src/hooks/useLiveKit.ts
@@ -375,6 +375,14 @@ export function useLiveKit({
       mixMicGainRef.current = null;
       mixSystemGainRef.current = null;
       mixDestRef.current = null;
+      // Stop auto-mix timer + analyser (prevent orphaned setInterval)
+      if (autoMixTimerRef.current) { clearInterval(autoMixTimerRef.current); autoMixTimerRef.current = null; }
+      autoMixAnalyserRef.current?.disconnect();
+      autoMixAnalyserRef.current = null;
+      autoMixRef.current = false;
+      // Stop active recording timer (blob is lost on unmount anyway)
+      if (recordingTimerRef.current) { clearInterval(recordingTimerRef.current); recordingTimerRef.current = null; }
+      recorderRef.current = null;
       // Remove all remote audio elements to prevent duplicates on reconnect
       document.querySelectorAll('audio[id^="lk-audio-"]').forEach((el) => el.remove());
       room.disconnect();


### PR DESCRIPTION
## Summary

Addresses all issues found by the PartyKit + LiveKit lifecycle audit.

## PartyKit fixes

### 1. mutedBySinger not cleared on empty room (Low)
**Before:** Singer mutes all, everyone leaves. New joiner sees stale "X muted everyone" banner.
**After:** Empty room resets all state including mutedBySinger.

### 2. Pre-join ghost connections (Medium)
**Before:** Connection opens WebSocket but never sends "join". Stays alive forever, accumulates.
**After:** 10s deadline - connections that don't join get disconnected. onClose also cleans up lastPong for pre-join connections.

### 3. Singer idle timeout (Medium)
**Before:** Singer holds stage forever while connected but not sharing. Only fires on disconnect.
**After:** 60s idle timer. Cancelled while actively sharing (unlimited singing time). Restarts when sharing stops. Auto-advances queue for idle singers.

## LiveKit fixes

### 4. MediaRecorder leak on disconnect (Medium)
**Before:** Tab close while recording leaves setInterval running in orphaned closure.
**After:** Recording timer cleared + recorder ref nulled in disconnect cleanup.

### 5. Auto-mix leak on disconnect (Medium)
**Before:** Tab close with auto-mix ON leaves setInterval running.
**After:** Auto-mix timer, analyser, and ref all cleaned in disconnect cleanup.

### 6. Token TTL (Low)
**Before:** 6-hour default from SDK.
**After:** 1-hour explicit TTL. Smaller window for stale tokens.

## Test plan
- [ ] Empty room -> rejoin -> no stale mute banner
- [ ] Open WS without joining -> disconnected after 10s
- [ ] Singer promoted -> 60s without sharing -> auto-advanced
- [ ] Singer sharing -> unlimited time -> stop sharing -> 60s -> auto-advanced
- [ ] Close tab while recording -> no console errors on next page
- [ ] Close tab with auto-mix ON -> no leaked intervals

## Risk
- Singer timeout behavior changes: connected idle singers now get auto-advanced. 60s is generous but could surprise singers who take a long time to set up tab audio sharing.